### PR TITLE
Add unit tests

### DIFF
--- a/attachment_test.go
+++ b/attachment_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tetsuya28/aws-cost-report/i18y"
+)
+
+func TestToAttachment(t *testing.T) {
+	err := i18y.Init()
+	assert.NoError(t, err)
+	Language = "en"
+
+	costs := []DailyCost{
+		{Services: map[string]ServiceDetail{"svc": {CostAmount: 1, CostUnit: "USD", UsageAmount: 1, UsageUnit: ""}}},
+		{Services: map[string]ServiceDetail{"svc": {CostAmount: 2, CostUnit: "USD", UsageAmount: 2, UsageUnit: ""}}},
+		{Services: map[string]ServiceDetail{"svc": {CostAmount: 3, CostUnit: "USD", UsageAmount: 3, UsageUnit: ""}}},
+	}
+
+	atts, err := toAttachment(costs)
+	assert.NoError(t, err)
+	if len(atts) == 0 {
+		t.Fatalf("no attachments returned")
+	}
+
+	a := atts[0]
+	assert.Equal(t, "#ff0000", a.Color)
+	fields := a.Fields
+	assert.Equal(t, i18y.Translate(Language, "cost"), fields[0].Title)
+	assert.Contains(t, fields[0].Value, "USD")
+}
+
+func TestToAttachmentInvalid(t *testing.T) {
+	_, err := toAttachment([]DailyCost{})
+	assert.Error(t, err)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	os.Setenv("SLACK_TOKEN", "test-token")
+	os.Setenv("SLACK_CHANNEL", "test-channel")
+	os.Setenv("LANGUAGE", "en")
+	defer os.Unsetenv("SLACK_TOKEN")
+	defer os.Unsetenv("SLACK_CHANNEL")
+	defer os.Unsetenv("LANGUAGE")
+
+	cfg, err := New()
+	assert.NoError(t, err)
+	assert.Equal(t, "test-token", cfg.SlackToken)
+	assert.Equal(t, "test-channel", cfg.SlackChannel)
+	assert.Equal(t, "en", cfg.Language)
+}

--- a/cost_test.go
+++ b/cost_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+	"github.com/stretchr/testify/assert"
+	"github.com/tetsuya28/aws-cost-report/testdata"
+)
+
+func TestToCost(t *testing.T) {
+	data, err := testdata.GetCostAndUsage()
+	assert.NoError(t, err)
+	if len(data.ResultsByTime) == 0 {
+		t.Fatalf("no result")
+	}
+
+	g := data.ResultsByTime[0].Groups[0]
+	detail, err := toCost(g)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, detail.CostAmount)
+	assert.Equal(t, "USD", detail.CostUnit)
+	assert.Equal(t, 0.0, detail.UsageAmount)
+	assert.Equal(t, "", detail.UsageUnit)
+
+	// nil group should not fail
+	d, err := toCost(&costexplorer.Group{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, d.CostAmount)
+}

--- a/external/aws_icon_test.go
+++ b/external/aws_icon_test.go
@@ -1,0 +1,15 @@
+package external
+
+import "testing"
+
+func TestGetIconURL(t *testing.T) {
+	url := GetIconURL("Amazon DynamoDB")
+	if url == "" {
+		t.Errorf("expected icon url for DynamoDB")
+	}
+
+	unknown := GetIconURL("Unknown Service")
+	if unknown != "" {
+		t.Errorf("expected empty url for unknown service")
+	}
+}

--- a/external/slack_test.go
+++ b/external/slack_test.go
@@ -1,0 +1,29 @@
+package external
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+func TestSlackClientPostMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat.postMessage" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}))
+	defer ts.Close()
+
+	c := slack.New("test-token", slack.OptionAPIURL(ts.URL+"/"))
+	s := SlackClient{client: c}
+
+	err := s.PostMessage("test", slack.MsgOptionText("hello", false))
+	if err != nil {
+		t.Fatalf("post message failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add test for config loader
- add tests for toCost and toAttachment helpers
- add test for icon URL helper
- add test for Slack client

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846339cac9c8331a4546d0628b6a848