### PR TITLE
Fix attachments initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,8 @@ func toAttachment(cost []DailyCost) ([]slack.Attachment, error) {
 		return nil, fmt.Errorf("cost length is not 3")
 	}
 
-	attachments := make([]slack.Attachment, len(cost[1].Services))
+	// preallocate slice capacity to avoid zero-valued entries
+	attachments := make([]slack.Attachment, 0, len(cost[1].Services))
 	for name, detail := range cost[1].Services {
 		color := "#00ff00"
 


### PR DESCRIPTION
## Summary
- fix toAttachment to avoid zero-valued slack.Attachment

## Testing
- `go test ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684636d530a0833187cb1aa1a003d706