### PR TITLE
Implement monthly cost notification

### DIFF
--- a/attachment_test.go
+++ b/attachment_test.go
@@ -13,9 +13,7 @@ func TestToAttachment(t *testing.T) {
 	Language = "en"
 
 	costs := []DailyCost{
-		{Services: map[string]ServiceDetail{"svc": {CostAmount: 1, CostUnit: "USD", UsageAmount: 1, UsageUnit: ""}}},
 		{Services: map[string]ServiceDetail{"svc": {CostAmount: 2, CostUnit: "USD", UsageAmount: 2, UsageUnit: ""}}},
-		{Services: map[string]ServiceDetail{"svc": {CostAmount: 3, CostUnit: "USD", UsageAmount: 3, UsageUnit: ""}}},
 	}
 
 	atts, err := toAttachment(costs)
@@ -25,7 +23,7 @@ func TestToAttachment(t *testing.T) {
 	}
 
 	a := atts[0]
-	assert.Equal(t, "#ff0000", a.Color)
+	assert.Equal(t, "#ffffff", a.Color)
 	fields := a.Fields
 	assert.Equal(t, i18y.Translate(Language, "cost"), fields[0].Title)
 	assert.Contains(t, fields[0].Value, "USD")

--- a/external/aws.go
+++ b/external/aws.go
@@ -80,10 +80,10 @@ func GetIconURL(service string) string {
 
 func GetCost() (*costexplorer.GetCostAndUsageOutput, error) {
 	now := time.Now()
-	end := now.Format("2006-01-02")
-	twoDaysBefore := now.AddDate(0, 0, -3).Format("2006-01-02")
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location()).Format("2006-01-02")
+	tomorrow := now.AddDate(0, 0, 1).Format("2006-01-02")
 
-	granularity := "DAILY"
+	granularity := "MONTHLY"
 	metrics := []string{
 		"AmortizedCost",
 		"BlendedCost",
@@ -101,8 +101,8 @@ func GetCost() (*costexplorer.GetCostAndUsageOutput, error) {
 	svc := costexplorer.New(sess)
 	result, err := svc.GetCostAndUsage(&costexplorer.GetCostAndUsageInput{
 		TimePeriod: &costexplorer.DateInterval{
-			Start: aws.String(twoDaysBefore),
-			End:   aws.String(end),
+			Start: aws.String(startOfMonth),
+			End:   aws.String(tomorrow),
 		},
 		Granularity: aws.String(granularity),
 		GroupBy: []*costexplorer.GroupDefinition{

--- a/i18y/languages/en.yaml
+++ b/i18y/languages/en.yaml
@@ -1,3 +1,3 @@
-title: "%s cost of %s is `$%.3f`"
+title: "%s cost of %s (MTD) is `$%.3f`"
 cost: Cost
 usage: Usage

--- a/i18y/languages/ja.yaml
+++ b/i18y/languages/ja.yaml
@@ -1,3 +1,3 @@
-title: "%s : %s のコスト : `$%.3f`"
+title: "%s : %s の累計コスト : `$%.3f`"
 cost: 料金
 usage: 利用量


### PR DESCRIPTION
## Summary
- notify month-to-date cost instead of previous day's cost
- simplify attachment details and adjust tests
- update i18n messages for monthly reporting

## Testing
- `make test` *(fails: access to Go modules is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684638f02ba08331beeeef29e5f38368