### PR TITLE
Fix SAM build by using go1.x runtime

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -56,8 +56,8 @@ Resources:
       BuildMethod: go1.x
     Properties:
       CodeUri: ./
-      Handler: bootstrap
-      Runtime: provided.al2023
+      Handler: main
+      Runtime: go1.x
       Role: !GetAtt BillingIamRole.Arn
       Architectures:
       - x86_64


### PR DESCRIPTION
## Summary
- Switch runtime from `provided.al2023` to `go1.x`
- Update handler to match compiled binary

## Testing
- `go test ./...` *(fails: downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68463a8c59508331966a9cfbb2994dec