### PR TITLE
Remove unused Messages type

### DIFF
--- a/i18y/i18y.go
+++ b/i18y/i18y.go
@@ -26,8 +26,6 @@ var (
 	configByte embed.FS
 )
 
-type Messages map[string]map[string]string
-
 func Init() error {
 	files, err := configByte.ReadDir(LanguagesDir)
 	if err != nil {


### PR DESCRIPTION
## Summary
- remove leftover Messages type from the i18y package

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684645c71aa08331a38059acc1a072b9